### PR TITLE
refactor: Use provider.fullname name as prefix instead of suffix

### DIFF
--- a/charts/provider/templates/deployment.yaml
+++ b/charts/provider/templates/deployment.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name:  {{ $chain.name | lower }}-{{ include "provider.fullname" $ }}
+  name:  {{ include "provider.fullname" $ }}-{{ $chain.name | lower }}
   labels:
     {{- include "provider.labels" $ | nindent 4 }}
     app.lavanet.io/chain: {{ $chain.name | lower }}
@@ -149,7 +149,7 @@ spec:
             {{- if $chain.existingConfigSecret }}
             secretName: {{ $chain.existingConfigSecret }}
             {{- else }}
-            secretName: {{ $chain.name | lower }}-{{ include "provider.fullname" $ }}
+            secretName: {{ include "provider.fullname" $ }}-{{ $chain.name | lower }}
             {{- end }}
         - name: "private-key-volume"
           secret:

--- a/charts/provider/templates/ingress.yaml
+++ b/charts/provider/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
             pathType: {{ $.Values.ingressGrpc.pathType }}
             backend:
               service:
-                name: {{ $chain.name | lower }}-{{ include "provider.fullname" $ }}
+                name: {{ include "provider.fullname" $ }}-{{ $chain.name | lower }}
                 port:
                   name: grpc
     {{- end }}

--- a/charts/provider/templates/pvc.yaml
+++ b/charts/provider/templates/pvc.yaml
@@ -5,7 +5,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name:  {{ $chain.name | lower }}-{{ include "provider.fullname" $ }}
+  name:  {{ include "provider.fullname" $ }}-{{ $chain.name | lower }}
   labels:
     {{- include "provider.labels" $ | nindent 4 }}
     app.lavanet.io/chain: {{ $chain.id | lower }}

--- a/charts/provider/templates/secret.yaml
+++ b/charts/provider/templates/secret.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $chain.name | lower }}-{{ include "provider.fullname" $ }}
+  name: {{ include "provider.fullname" $ }}-{{ $chain.name | lower }}
   labels:
     {{- include "provider.labels" $ | nindent 4 }}
     app.lavanet.io/chain: {{ $chain.id | lower }}

--- a/charts/provider/templates/service.yaml
+++ b/charts/provider/templates/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $chain.name | lower }}-{{ include "provider.fullname" $ }}
+  name: {{ include "provider.fullname" $ }}-{{ $chain.name | lower }}
   labels:
     {{- include "provider.labels" $ | nindent 4 }}
     app.lavanet.io/chain: {{ $chain.name | lower }}

--- a/charts/provider/templates/statefulset.yaml
+++ b/charts/provider/templates/statefulset.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name:  {{ $chain.name | lower }}-{{ include "provider.fullname" $ }}
+  name:  {{ include "provider.fullname" $ }}-{{ $chain.name | lower }}
   labels:
     {{- include "provider.labels" $ | nindent 4 }}
     app.lavanet.io/chain: {{ $chain.name | lower }}
@@ -153,7 +153,7 @@ spec:
             {{- if $chain.existingConfigSecret }}
             secretName: {{ $chain.existingConfigSecret }}
             {{- else }}
-            secretName: {{ $chain.name | lower }}-{{ include "provider.fullname" $ }}
+            secretName: {{ include "provider.fullname" $ }}-{{ $chain.name | lower }}
             {{- end }}
         - name: "private-key-volume"
           secret:
@@ -163,7 +163,7 @@ spec:
           {{- if $chain.persistence }}
           {{- if $chain.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ $chain.name | lower }}-{{ include "provider.fullname" $ }}
+            claimName: {{ include "provider.fullname" $ }}-{{ $chain.name | lower }}
           {{- else }}
           emptyDir: {}
           {{- end }}


### PR DESCRIPTION
This PR sets `provider.fullname` as a prefix rather than suffix on chain-specific resources. This results in better readability when listing resources.

Suffix
```
arbitrum-mainnet-provider-testnet-768b87f799-xdfrn
axelar-mainnet-provider-testnet-869dc44f47-zxkzj  
axelar-testnet-provider-testnet-6c4bcd5f8b-nr4mv  
celo-mainnet-provider-testnet-775864fdb7-9bngg    
cosmoshub-mainnet-provider-testnet-d9df8d989-gdljv
ethereum-mainnet-provider-testnet-69c87cdd88-8gqgz
```

Prefix
```
provider-testnet-arbitrum-mainnet-768b87f799-xdfrn
provider-testnet-axelar-mainnet-869dc44f47-zxkzj  
provider-testnet-axelar-testnet-6c4bcd5f8b-nr4mv  
provider-testnet-celo-mainnet-775864fdb7-9bngg    
provider-testnet-cosmoshub-mainnet-d9df8d989-gdljv
provider-testnet-ethereum-mainnet-69c87cdd88-8gqgz
```