### PR TITLE
fix: change authConfig to optional

### DIFF
--- a/charts/provider/templates/secret.yaml
+++ b/charts/provider/templates/secret.yaml
@@ -26,13 +26,17 @@ endpoints:
     node-urls:
     {{- range $node := $interfaceEntry.nodes }}
       - url: {{ $node.endpoint | quote }}
-      {{- if $node.authConfig.enabled }}
+      {{- with $node.authConfig }}
+        {{- if .enabled }}
         auth-config:
-        {{- if $node.authConfig.authHeaders.enabled }}
+        {{- with .authHeaders }}
+          {{- if .enabled }}
           auth-headers:
-            {{- range $header, $value := $node.authConfig.authHeaders.headers }}
-              {{- $header }}: {{- $value }}
-            {{- end }}
+          {{- range $header, $value := .headers }}
+            {{ $header }}: "{{ $value }}"
+          {{- end }}
+          {{- end }}
+        {{- end }}
         {{- end }}
       {{- end }}
       {{- if ne $node.type "full" }}


### PR DESCRIPTION
* Changed `authConfig` to be optional so that providers who dont use it in the helm chart wont fail