### PR TITLE
feat: :sparkles: added ability to name static providers

### DIFF
--- a/charts/consumer/templates/configmap.yaml
+++ b/charts/consumer/templates/configmap.yaml
@@ -25,6 +25,9 @@ data:
     {{- if $interfaceEntry.staticProviders }}
       - chain-id: {{ $itemKey | upper }}
         api-interface: {{ $interfaceEntry.interface }}
+        {{- if $interfaceEntry.name }}
+        provider-name: {{ $interfaceEntry.name }}
+        {{- end }}
         node-urls:
         {{- range $staticProvider := $interfaceEntry.staticProviders }}
           - url: {{ $staticProvider.url }}


### PR DESCRIPTION
# Description

Closes: nothing

Corresponds to: https://github.com/lavanet/lava/pull/2025
Added ability to name individual static providers.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] read the [contribution guide](https://github.com/lavanet/ansible/blob/main/CONTRIBUTING.md)
* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
* [x] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] ran `ansible-lint` and made sure there are no errors
* [x] updated the relevant documentation or specification
* [x] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed all author checklist items have been addressed
* [x] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
