### PR TITLE
fix: Ensure pod template annotations are rendered for provider deployments

### DIFF
--- a/charts/provider/Chart.yaml
+++ b/charts/provider/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://github.com/lavanet/helm-charts/blob/main/docs/logo/logo.png?raw=tr
 sources:
   - https://github.com/lavanet/helm-charts
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: "v2.5.0"
 kubeVersion: ">=1.25.0-0"
 home: https://lavanet.xyz

--- a/charts/provider/templates/deployment.yaml
+++ b/charts/provider/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       app.lavanet.io/chain: {{ $chain.name | lower }}
   template:
     metadata:
+      {{- if $.Values.podAnnotations}}
       annotations:
         {{- with $.Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
@@ -33,6 +34,7 @@ spec:
         {{- if not $chain.existingConfigSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") $ | sha256sum }}
         {{- end }}
+      {{- end }}
       labels:
         {{- include "provider.selectorLabels" $ | nindent 8 }}
         app.lavanet.io/chain: {{ $chain.name | lower }}


### PR DESCRIPTION
**Summary**

Fixes an issue in ArgoCD-managed deployments where `kubectl rollout restart` would create a new pod that was immediately terminated instead of performing a proper rolling restart.

**Root cause**

The chart did not consistently render `spec.template.metadata.annotations`. When no pod annotations were configured, the pod template effectively had no annotations map. During a rollout restart, kubectl temporarily injects `kubectl.kubernetes.io/restartedAt`, but in ArgoCD-managed deployments this change was later overwritten when the Deployment was reconciled from the rendered manifest. This caused the pod template hash to revert and the newly created ReplicaSet to be scaled down immediately.

**Fix**

Ensure the pod template annotations block is rendered when pod annotations are provided. This stabilizes the pod template metadata and prevents the restart annotation from being removed during reconciliation, allowing Kubernetes to complete a normal rolling update.

**Result**

`kubectl rollout restart` now behaves as expected in ArgoCD-managed deployments, replacing the old pod with a new one via a proper rolling deployment.
